### PR TITLE
change folder permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p /usr/share/fonts/truetype \
     && tar -xf /templates/common/arimo.tar.xz -C /usr/share/fonts/truetype/ \
     && rm /templates/common/*.tar.xz \
     && mv /templates/example /example \
-    && chmod 0644 -R /templates && chmod 0644 -R /example && chmod 0744 /entrypoint.sh \
+    && chmod 0755 -R /templates && chmod 0755 -R /example && chmod 0744 /entrypoint.sh \
     && fc-cache -f && rm -rf /var/cache/*
 
 WORKDIR /data


### PR DESCRIPTION
for docker the folder permission needs to be 755 to get excess to the example folders. until i found another solution for that problem, i fix the permission problem like that way.